### PR TITLE
Add CI support

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -3,3 +3,4 @@ roles/*
 defaults/*.yml
 !defaults/*.example.yml
 !defaults/main.yml
+!defaults/template_info.yml

--- a/ansible/defaults/template_info.yml
+++ b/ansible/defaults/template_info.yml
@@ -1,0 +1,37 @@
+---
+project_name: project_name
+sshkey_folder: /home/user/.ssh/
+## Example on how to define a host_list map to create multiple hosts and/or create hosts on multiple providers.
+## Tags/lables will be used as ansible groups so you can easily apply certain playbooks/roles against specific hosts.
+## This means that the host will be added ansible groups with the same name of the tags/label added below.
+## For all the options you can define per host look at the terraform.tfvars.j2 template.
+## For example you overwrite the size of the VM or the OS by adding it to this map.
+#
+# host_list: {
+#   digitalocean: [
+#     { "name": "host01",
+#       "tags": "[\"nginx\"]"
+#     },
+#     { "name": "host02",
+#       "tags": "[\"mysql\"]"
+#     },
+#   ],
+#   hetzner: [
+#     { "name": "host03",
+#       "labels": "{postfix = \"\"}"
+#     }
+#   ]
+# }
+#
+
+host_list: {
+  digitalocean: [
+    { "name": "host01",
+      "tags": "[\"ansible\"]"
+    },
+  ]
+}
+
+root_username: root
+root_private_key_path: "{{ sshkey_folder }}/{{ root_username }}-{{ project_name }}"
+root_public_key_path: "{{ sshkey_folder }}/{{ root_username }}-{{ project_name }}.pub"

--- a/ansible/playbooks/terraform/create.yml
+++ b/ansible/playbooks/terraform/create.yml
@@ -7,11 +7,35 @@
     - "{{ playbook_dir }}/../../defaults/secrets.yml"
 
   pre_tasks:
+    - name: Ensure .ssh directory exists
+      file: 
+        dest: "{{ sshkey_folder }}"
+        mode: 0700 
+        owner: "{{ lookup('env', 'USER') }}"
+        state: directory      
+
     - name: Ensure the needed ssh keys are created
       community.crypto.openssh_keypair:
         path: "{{ sshkey_folder }}/{{ item }}-{{ project_name }}"
       with_items:
         - "{{ root_username }}"
+      when: ssh_key is not defined
+        
+    - name: Using supplied SSH private key
+      copy: 
+        content: "{{ ssh_key.private.replace('\\n', '\n')  }}" 
+        dest: "{{ sshkey_folder }}/{{ root_username }}-{{ project_name }}"
+        mode: 0600
+        owner: "{{ lookup('env', 'USER') }}"
+      when: ssh_key is defined
+
+    - name: Using supplied SSH public key
+      copy: 
+        content: "{{ ssh_key.public }}" 
+        dest: "{{ sshkey_folder }}/{{ root_username }}-{{ project_name }}.pub"
+        mode: 0600
+        owner: "{{ lookup('env', 'USER') }}"
+      when: ssh_key is defined
 
     - name: Ensure 'terraform.tfvars' template is deployed
       ansible.builtin.template:

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "local" {}
+}
+
+# terraform {
+#  backend "remote" {
+#    hostname = "app.terraform.io"
+#    organization = "org"
+# 
+#    workspaces {
+#      name = "space"
+#     }
+#   }
+# }


### PR DESCRIPTION
Small edit to allow interrogation into CI's such as Github Actions. 

- Remote state/backend example is included, defaults to local. Needs entry in wiki on how to set this up.
- Added template_info.yml to src

## Bring Your Own Private key

Example command that can be ran from a CI. SSH Private key has `\n` new line delimiters.

```
ansible-playbook main.yml --tags=create --extra-vars "{'tokens':{'digitalocean':'dop_v1_[...SNIP...]]'},'ssh_key':{'private':'-----BEGIN OPENSSH PRIVATE KEY-----\nAAAAAAAAAAAA\n[...SNIP..]ZZZZZZ\n-----END OPENSSH PRIVATE KEY-----','public':'ssh-rsa A[...SNIP..]Z'}}"
```
